### PR TITLE
Feature / Password Email View

### DIFF
--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -8,10 +8,14 @@
                 <strong>{{ $message }}</strong>
             </span>
             @enderror
-            <x-button type="submit">Wachtwoord resetten</x-button>
-            <span class="text-blue-500 underline">
-            <a href="{{ route('login') }}">Toch inloggen</a>
-        </span>
+            <div class="flex">
+                <div class="mr-4">
+                    <x-button type="submit">Wachtwoord resetten</x-button>
+                </div>
+                <div class="self-end">
+                    <a href="{{ route('login') }}" class="text-blue-500 underline">Toch inloggen</a>
+                </div>
+            </div>
         </form>
     </x-card>
 </x-layout>


### PR DESCRIPTION
# Implement Password Email View

## Description
The older version of the password reset page had no styling, as it still used Bootstrap classes. These have been updated with Tailwind, through the available components.

Under the screenshots, you can see the wireframe and the view itself.

## Testing

For testing, pull in this branch and follow the following steps:
1. Run php artisan serve
2. In a different terminal window, run npm run watch
3. Go to your local hosted website
4. Use /password/reset as your Url path

## Changes

The only changes are in email.blade.php. Here, the card, input and button components are used to implement an email input for the resetting of a password.

## Screenshots

### Wireframe
![image](https://user-images.githubusercontent.com/63709758/110504305-510fc000-80fd-11eb-8f4f-c0391a2c6fc0.png)

### The View
![image](https://user-images.githubusercontent.com/63709758/110504403-6b499e00-80fd-11eb-82fe-d8b8723e18eb.png)