### PR TITLE
"view" for searchbar

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -5,7 +5,7 @@
 
             <div class="sticky top-0">
                 <div class="mb-8">
-                    <span class="absolute pl-3 pt-3 text-gray-600">
+                    <span class="absolute pl-3 pt-2 md:pt-3 text-gray-600">
                         <i class="fas fa-search"></i>
                     </span>
                     <input type="text" name="searchbar" id="searchbar" placeholder="Zoeken..." class="text-xs sm:text-sm md:text-base lg:text-lg px-2.5 py-2.5 pl-8 w-full rounded border-gray-400 focus:border-gray-400 text-gray-600 focus:ring-0"/>


### PR DESCRIPTION
screenshot:
![image](https://user-images.githubusercontent.com/49642825/115998434-755d2880-a5e7-11eb-887c-9d2004a51257.png)

blijft boven aan staan bij scrollen filters:
![image](https://user-images.githubusercontent.com/49642825/115998456-945bba80-a5e7-11eb-97a4-bfea3533df30.png)
