### PR TITLE
Fix move create and store from employeecontroller to registrationcontroller

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -3,10 +3,20 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Expertise;
 use App\Models\Role;
+use App\Models\WorkDay;
 use App\Providers\RouteServiceProvider;
 use App\Models\User;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\RegistersUsers;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
@@ -19,8 +29,8 @@ class RegisterController extends Controller
     |--------------------------------------------------------------------------
     |
     | This controller handles the registration of new users as well as their
-    | validation and creation. By default this controller uses a trait to
-    | provide this functionality without requiring any additional code.
+    | validation and creation. This controller also handles finalization of
+    | the registration by creating and storing an employee model.
     |
     */
 
@@ -32,16 +42,6 @@ class RegisterController extends Controller
      * @var string
      */
     protected $redirectTo = RouteServiceProvider::HOME;
-
-    /**
-     * Create a new controller instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->middleware('auth');
-    }
 
     public function index() {
         $user = auth()->user();
@@ -56,32 +56,59 @@ class RegisterController extends Controller
     }
 
     /**
-     * Get a validator for an incoming registration request.
+     * Validates an incoming registration request.
      *
-     * @param  array  $data
-     * @return \Illuminate\Contracts\Validation\Validator
      */
-    protected function validator(array $data)
+    protected function validateEmployee()
     {
-        return Validator::make($data, [
-            'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        return request()->validate([
+            'user_id' => 'required|unique:employees',
+            'firstname' => 'required|alpha|min:2|max:40',
+            'lastname' => 'required|min:2|max:40',
+            'phoneNumber' => array('required', 'regex:/^((\+31)|(0031)|0)(\(0\)|)(\d{1,3})(\s|\-|)(\d{8}|\d{4}\s\d{4}|\d{2}\s\d{2}\s\d{2}\s\d{2})$/'),
+            'departments' => 'required|exists:departments,id',
+            'expertises' => 'required|exists:expertises,id',
+            'roles' => 'required|exists:roles,id',
+            'workDays' => 'required|exists:work_days,id',
         ]);
     }
 
     /**
-     * Create a new user instance after a valid registration.
+     * Show the form for creating a new resource.
      *
-     * @param  array  $data
-     * @return User
+     * @return Application|Factory|View|Response
      */
-    protected function create(array $data)
+    public function create()
     {
-        return User::create([
-            'name' => $data['name'],
-            'email' => $data['email'],
-            'password' => Hash::make($data['password']),
-        ]);
+        $user = Auth::user();
+        $departments = Department::all()->pluck('name', 'id');
+        $roles = Role::all()->whereNotIn('id', 1)->pluck('name', 'id');
+        $expertises = Expertise::all()->pluck('name', 'id');
+        $workDays = WorkDay::all();
+
+        return view('employee.create', compact(['user', 'departments', 'roles', 'expertises', 'workDays']));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param Request $request
+     * @return RedirectResponse
+     */
+    public function store()
+    {
+        $validated = $this->validateEmployee();
+
+        $employee = Employee::create($validated);
+
+        $employee->departments()->sync($validated['departments']);
+        $employee->expertises()->sync($validated['expertises']);
+        $employee->workDays()->sync($validated['workDays']);
+        $employee->save();
+
+        $employee->user->roles()->sync($validated['roles']);
+        $employee->user->save();
+
+        return redirect(route('home'));
     }
 }

--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -13,69 +13,12 @@ use App\Models\Lectorate;
 use App\Models\Minor;
 use App\Models\Role;
 use App\Models\WorkDay;
-use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Contracts\View\Factory;
-use Illuminate\Contracts\View\View;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 
 class EmployeeController extends Controller
 {
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return Application|Factory|View|Response
-     */
-    public function create()
-    {
-        $user = Auth::user();
-        $departments = Department::all()->pluck('name', 'id');
-        $roles = Role::all()->whereNotIn('id', 1)->pluck('name', 'id');
-        $expertises = Expertise::all()->pluck('name', 'id');
-        $workDays = WorkDay::all();
-
-        return view('employee.create', compact(['user', 'departments', 'roles', 'expertises', 'workDays']));
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param Request $request
-     * @return RedirectResponse
-     */
-    public function store()
-    {
-        $validated = $this->validateEmployee();
-
-        $employee = Employee::create($validated);
-
-        $employee->departments()->sync($validated['departments']);
-        $employee->expertises()->sync($validated['expertises']);
-        $employee->workDays()->sync($validated['workDays']);
-        $employee->save();
-
-        $employee->user->roles()->sync($validated['roles']);
-        $employee->user->save();
-
-        return redirect(route('home'));
-    }
-
-    protected function validateEmployee()
-    {
-        return request()->validate([
-            'user_id' => 'required|unique:employees',
-            'firstname' => 'required|alpha|min:2|max:40',
-            'lastname' => 'required|min:2|max:40',
-            'phoneNumber' => array('required', 'regex:/^((\+31)|(0031)|0)(\(0\)|)(\d{1,3})(\s|\-|)(\d{8}|\d{4}\s\d{4}|\d{2}\s\d{2}\s\d{2}\s\d{2})$/'),
-            'departments' => 'required|exists:departments,id',
-            'expertises' => 'required|exists:expertises,id',
-            'roles' => 'required|exists:roles,id',
-            'workDays' => 'required|exists:work_days,id',
-        ]);
-    }
-
     /**
      * Display the specified resource.
      *

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,11 +23,10 @@ Auth::routes();
 Route::group(['middleware' => 'auth'], function () {
 
     Route::group(['middleware' => 'employee.empty', 'prefix' => 'employee', 'as' => 'employee.'], function () {
-        Route::get('/create', [EmployeeController::class, 'create'])->name('create');
-        Route::post('/', [EmployeeController::class, 'store'])->name('store');
+        Route::get('/create', [RegisterController::class, 'create'])->name('create');
+        Route::post('/', [RegisterController::class, 'store'])->name('store');
     });
 
-    Route::resource('employee', EmployeeController::class);
     Route::group(['middleware' => 'employee'], function () {
 
         Route::get('/', [HomeController::class, 'index'])->name('home');
@@ -37,7 +36,7 @@ Route::group(['middleware' => 'auth'], function () {
         Route::post('/', [UserController::class, 'registerNewUser'])->name('registerNewUser');
 
         Route::resource('employee', EmployeeController::class)
-            ->only(['show']);
+            ->only(['show', 'edit', 'update']);
     });
 });
 


### PR DESCRIPTION
- Moved create, store and validation methods from EmployeeController to RegistrationController.
- Dots on the i within RegistrationController.
- Adjusted routes to RegistrationController.
- Removed employee resource route and added them within the employee middleware.

To test login as test@avans.nl or any other.
Remove the employee entry from your local smoelenboek DB.
Reload to prompt the registration screen. 
Fill in some valid data and press save.