### PR TITLE
Make search separator "," instead of " "

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -9,6 +9,7 @@ use App\Models\Role;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\RegistersUsers;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
@@ -62,7 +63,7 @@ class RegisterController extends Controller
      * Create a new user instance after a valid registration.
      *
      * @param  array  $data
-     * @return \Illuminate\Http\RedirectResponse
+     * @return RedirectResponse
      */
     public function store(CreateUserRequest $request)
     {

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -25,7 +25,6 @@ use App\Models\SearchBar;
 use App\Models\WorkDay;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 
 class HomeController extends Controller
 {

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class Employee extends Model
 {
     use HasFactory;
-    
+
     protected $fillable = [
         'user_id',
         'firstname',

--- a/app/Models/SearchBar.php
+++ b/app/Models/SearchBar.php
@@ -9,7 +9,7 @@ class SearchBar extends Facade
 {
     public function search(Collection $employees, string $search): Collection
     {
-        $filters = explode(" ", $search);
+        $filters = explode(",", str_replace(", ", ",", $search));
 
         $expertises = $this->filter(Expertise::all(), $filters);
         $courses = $this->filter(Course::all(), $filters);


### PR DESCRIPTION
# Multisearch

The title says it all.

## Extra information
Before the search string explodes, all whitespace after a `,` is removed because otherwise, the code will look for something with a space in front of it.

### Example without the removal of the white space
If you want to search John and Jane
The search is `John, Jane`
But the filters would be
`john`
' jane`